### PR TITLE
Fixing bug regarding extension appearing in region name metadata of .p file upon export

### DIFF
--- a/editor/src/com/talosvfx/talos/editor/wrappers/PolylineModuleWrapper.java
+++ b/editor/src/com/talosvfx/talos/editor/wrappers/PolylineModuleWrapper.java
@@ -119,7 +119,8 @@ public class PolylineModuleWrapper extends TextureDropModuleWrapper<PolylineModu
             module.setRegion(fileHandle.nameWithoutExtension(), region);
             dropWidget.setDrawable(new TextureRegionDrawable(region));
         }
-        fileName = fileHandle.nameWithoutExtension();
+        filePath = fileHandle.path();
+        regionName = fileHandle.nameWithoutExtension();
     }
 
     @Override

--- a/editor/src/com/talosvfx/talos/editor/wrappers/TextureDropModuleWrapper.java
+++ b/editor/src/com/talosvfx/talos/editor/wrappers/TextureDropModuleWrapper.java
@@ -38,7 +38,8 @@ public abstract class TextureDropModuleWrapper<T extends AbstractModule> extends
     protected TextureDropWidget<AbstractModule> dropWidget;
     protected TextureRegion defaultRegion;
 
-    protected String fileName = "fire";
+    protected String regionName = "fire";
+    protected String filePath = null;
 
     @Override
     protected void configureSlots() {
@@ -65,7 +66,8 @@ public abstract class TextureDropModuleWrapper<T extends AbstractModule> extends
                 setModuleRegion(fileHandle.nameWithoutExtension(), region);
                 dropWidget.setDrawable(new TextureRegionDrawable(region));
 
-                fileName = fileHandle.nameWithoutExtension();
+                regionName = fileHandle.nameWithoutExtension();
+                filePath = fileHandle.path();
 
                 TalosMain.Instance().FileTracker().trackFile(fileHandle, new FileTracker.Tracker() {
                     @Override
@@ -87,21 +89,32 @@ public abstract class TextureDropModuleWrapper<T extends AbstractModule> extends
     public void read(Json json, JsonValue jsonData) {
         super.read(json, jsonData);
 
-        String fileNameFromJson = jsonData.getString("fileName", null);
-        
-        fileName = fileNameFromJson.contains(".") ? fileNameFromJson.substring(0, fileNameFromJson.lastIndexOf(".")) : fileNameFromJson;
+        filePath = jsonData.getString("filePath", null);
+        regionName = jsonData.getString("regionName", null);
+
+        // hack for older version to patch broken files (we should do version transition logic and move it there later)
+        if(jsonData.has("fileName")) {
+            filePath = jsonData.getString("fileName");
+            regionName = filePath;
+            if(filePath.contains(".")) {
+                regionName =  regionName.substring(0, regionName.lastIndexOf("."));
+            } else {
+                filePath = filePath + ".png";
+            }
+        }
     
         final TalosAssetProvider assetProvider = TalosMain.Instance().TalosProject().getProjectAssetProvider();
-        final Sprite textureRegion = assetProvider.findAsset(fileName, Sprite.class);
+        final Sprite textureRegion = assetProvider.findAsset(regionName, Sprite.class);
 
-        setModuleRegion(fileName, textureRegion);
+        setModuleRegion(regionName, textureRegion);
         dropWidget.setDrawable(new TextureRegionDrawable(textureRegion));
     }
 
     @Override
     public void write (Json json) {
         super.write(json);
-        json.writeValue("fileName", fileName);
+        json.writeValue("filePath", filePath);
+        json.writeValue("regionName", regionName);
     }
 
     private FileHandle tryAndFindTexture(String path) {
@@ -128,6 +141,7 @@ public abstract class TextureDropModuleWrapper<T extends AbstractModule> extends
             setModuleRegion(fileHandle.nameWithoutExtension(), region);
             dropWidget.setDrawable(new TextureRegionDrawable(region));
         }
-        fileName = fileHandle.nameWithoutExtension();
+        filePath = fileHandle.path();
+        regionName = fileHandle.nameWithoutExtension();
     }
 }

--- a/editor/src/com/talosvfx/talos/editor/wrappers/TextureDropModuleWrapper.java
+++ b/editor/src/com/talosvfx/talos/editor/wrappers/TextureDropModuleWrapper.java
@@ -87,8 +87,10 @@ public abstract class TextureDropModuleWrapper<T extends AbstractModule> extends
     public void read(Json json, JsonValue jsonData) {
         super.read(json, jsonData);
 
-        fileName = jsonData.getString("fileName", null);
-
+        String fileNameFromJson = jsonData.getString("fileName", null);
+        
+        fileName = fileNameFromJson.contains(".") ? fileNameFromJson.substring(0, fileNameFromJson.lastIndexOf(".")) : fileNameFromJson;
+    
         final TalosAssetProvider assetProvider = TalosMain.Instance().TalosProject().getProjectAssetProvider();
         final Sprite textureRegion = assetProvider.findAsset(fileName, Sprite.class);
 

--- a/runtimes/talos-libgdx/src/com/talosvfx/talos/runtime/modules/TextureModule.java
+++ b/runtimes/talos-libgdx/src/com/talosvfx/talos/runtime/modules/TextureModule.java
@@ -46,11 +46,7 @@ public class TextureModule extends AbstractModule {
     }
 
     public void setRegion (String regionName, Sprite region) {
-        if (regionName.contains(".")) {
-            this.regionName = regionName.substring(0, regionName.lastIndexOf("."));
-        } else {
-            this.regionName = regionName;
-        }
+        this.regionName = regionName;
         
         if (region != null) {
             userDrawable.setDrawable(new TextureRegionDrawable(region));
@@ -67,7 +63,7 @@ public class TextureModule extends AbstractModule {
     @Override
     public void write (Json json) {
         super.write(json);
-        json.writeValue("regionName", regionName);
+        json.writeValue("regionName", regionName.substring(0, regionName.lastIndexOf(".")));
     }
 
     @Override

--- a/runtimes/talos-libgdx/src/com/talosvfx/talos/runtime/modules/TextureModule.java
+++ b/runtimes/talos-libgdx/src/com/talosvfx/talos/runtime/modules/TextureModule.java
@@ -46,8 +46,13 @@ public class TextureModule extends AbstractModule {
     }
 
     public void setRegion (String regionName, Sprite region) {
-        this.regionName = regionName;
-        if(region != null) {
+        if (regionName.contains(".")) {
+            this.regionName = regionName.substring(0, regionName.lastIndexOf("."));
+        } else {
+            this.regionName = regionName;
+        }
+        
+        if (region != null) {
             userDrawable.setDrawable(new TextureRegionDrawable(region));
         }
     }

--- a/runtimes/talos-libgdx/src/com/talosvfx/talos/runtime/modules/TextureModule.java
+++ b/runtimes/talos-libgdx/src/com/talosvfx/talos/runtime/modules/TextureModule.java
@@ -63,7 +63,7 @@ public class TextureModule extends AbstractModule {
     @Override
     public void write (Json json) {
         super.write(json);
-        json.writeValue("regionName", regionName.substring(0, regionName.lastIndexOf(".")));
+        json.writeValue("regionName", regionName);
     }
 
     @Override


### PR DESCRIPTION
This had multiple reasons, but mainly because while we need to keep both path and region names for .tls bookkeeping,  and only fileName was used, to keep sometimes regionName and sometimes fileName. This was bad.
as a solution, I removed that field and introduced two more appropriate names to keep data separate and properly. Additionally, because this is a data structure change I had to write a short migration "if" in reading to support older data versions. Will be great to move this somewhere else later when we support data versioning (I think it's part of the roadmap, but if not it should be)