### PR TITLE
ShaderDescriptor handler into AtlasAssetProvider + small fix

### DIFF
--- a/runtimes/talos-libgdx/src/com/talosvfx/talos/runtime/assets/AtlasAssetProvider.java
+++ b/runtimes/talos-libgdx/src/com/talosvfx/talos/runtime/assets/AtlasAssetProvider.java
@@ -1,8 +1,12 @@
 package com.talosvfx.talos.runtime.assets;
 
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.g2d.Sprite;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.utils.ObjectMap;
+import com.talosvfx.talos.runtime.utils.ShaderDescriptor;
 
 public class AtlasAssetProvider extends BaseAssetProvider {
     private final TextureAtlas atlas;
@@ -21,6 +25,28 @@ public class AtlasAssetProvider extends BaseAssetProvider {
             @Override
             public Sprite findAsset (String assetName) {
                 return atlas.createSprite(assetName);
+            }
+        });
+        
+        setAssetHandler(ShaderDescriptor.class, new AssetHandler<ShaderDescriptor>() {
+
+            private final ObjectMap<String, ShaderDescriptor> shaderDescriptorMap = new ObjectMap<>();
+            /**
+            * assetName: filename of the Shader (*.shdr file)
+            **/
+            @Override
+            public ShaderDescriptor findAsset(String assetName) {
+                ShaderDescriptor asset = shaderDescriptorMap.get(assetName);
+                if (asset == null) {
+                    final FileHandle file = Gdx.files.internal(assetName);
+
+                    asset = new ShaderDescriptor();
+                    if (file.exists()) {
+                        asset.setData(file.readString());
+                        shaderDescriptorMap.put(assetName, asset);
+                    }
+                }
+                return asset;
             }
         });
     }

--- a/runtimes/talos-libgdx/src/com/talosvfx/talos/runtime/values/NumericalValue.java
+++ b/runtimes/talos-libgdx/src/com/talosvfx/talos/runtime/values/NumericalValue.java
@@ -162,7 +162,7 @@ public class NumericalValue extends Value {
 		elements[0] = val1;
 		elements[1] = val2;
 		elements[2] = val3;
-		elements[3] = val3;
+		elements[3] = val4;
 	}
 
 	public float getFloat() {


### PR DESCRIPTION
1) Added ShaderDescriptor into AtlasAssetProvider.

It would also be great if we could rename the AtlasAssetProvider -> DefaultAssetProvider(or something generic) as there is only one asset provider required by ParticleEffectDescriptor, which will be used by all internal asset find calls. Have left the decision to rename this class to you guys.

2) Updated set method to use correct value.
set(float val1, float val2, float val3, float val4) was setting elements[3] with val3.