### PR TITLE
gameObject move into child bug

### DIFF
--- a/editor/src/com/talosvfx/talos/editor/widgets/ui/FilteredTree.java
+++ b/editor/src/com/talosvfx/talos/editor/widgets/ui/FilteredTree.java
@@ -334,6 +334,14 @@ public class FilteredTree<T> extends WidgetGroup {
                     Node<T> payloadParent = targetNodeToDrop.getParent();
                     Node<T> payloadNode = targetNodeToDrop;
 
+                    Node<T> parentNode = node;
+                    while (parentNode.parent != null) {
+                        if (parentNode.parent == payloadNode) {
+                            return;
+                        }
+                        parentNode = parentNode.parent;
+                    }
+
                     boolean sameLayer = payloadParent == node.getParent();
 
 


### PR DESCRIPTION
the game is crashing when trying to move object into child
in this case do nothing