### PR TITLE
Fix crash when creating a new shader

### DIFF
--- a/editor/src/com/talosvfx/talos/editor/addons/shader/ShaderProject.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/shader/ShaderProject.java
@@ -88,6 +88,9 @@ public class ShaderProject implements IProject {
 
         @Override
         public void write (Json json) {
+            if (projectMetadata == null) {
+                projectMetadata = new ProjectMetadata();
+            }
             projectMetadata.version = TalosVersion.getVersion();
             json.writeValue("metadata", projectMetadata);
             json.writeValue("nodes", nodeStage);


### PR DESCRIPTION
From the main menu, Shader Graph -> New Shader crashes with a null pointer exception. 

This commit ensures that ShaderProject$ProjectData.projectMetadata is instantiated before trying to write to it, allowing a new shader to be created via the menu.