### PR TITLE
Fix crash when changing color node value

### DIFF
--- a/editor/src/com/talosvfx/talos/editor/UIStage.java
+++ b/editor/src/com/talosvfx/talos/editor/UIStage.java
@@ -132,12 +132,12 @@ public class UIStage {
 		WrapperRegistry.map.clear();
 		moduleListPopup = new ModuleListPopup(root);
 
-//		colorPicker = new ColorPicker();
-//		colorPicker.padTop(32);
-//		colorPicker.padLeft(16);
-//		colorPicker.setHeight(330);
-//		colorPicker.setWidth(430);
-//		colorPicker.padRight(26);
+		colorPicker = new ColorPicker();
+		colorPicker.padTop(32);
+		colorPicker.padLeft(16);
+		colorPicker.setHeight(330);
+		colorPicker.setWidth(430);
+		colorPicker.padRight(26);
 	}
 
 	public boolean isIn3DMode () {


### PR DESCRIPTION
ColorPicker initialization in UIStage.init() was commented out in https://github.com/rockbite/talos/pull/162/commits/67ce2149b852715dc9deae21a46b7fd0167a66a6, so setting the value in a Color node would cause a crash in UIStage.showColorPicker().

This commit restores the ColorPicker initialization and fixes that crash.

If the initialization was commented out for a different reason, I can rework this to instantiate ColorPicker only if null in UIStage.showColorPicker().