### PR TITLE
Routine node deleted bug

### DIFF
--- a/editor/src/com/talosvfx/talos/editor/nodes/EmptyWindow.java
+++ b/editor/src/com/talosvfx/talos/editor/nodes/EmptyWindow.java
@@ -5,6 +5,7 @@ import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.scenes.scene2d.*;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.talosvfx.talos.editor.project2.SharedResources;
 
 public abstract class EmptyWindow extends Table {
 
@@ -218,7 +219,7 @@ public abstract class EmptyWindow extends Table {
 
     public void draw(Batch batch, float parentAlpha) {
         Stage stage = this.getStage();
-        if (stage != null && stage.getKeyboardFocus() == null) {
+        if (stage != null && stage.getKeyboardFocus() == null && SharedResources.stage.getKeyboardFocus() == null) {
             stage.setKeyboardFocus(this);
         }
 


### PR DESCRIPTION
Routine node deleted when typing delete or backspace in searchNode window

The problem is that in EmptyWindow/draw() method we set  keyboard focus  EmptyWindow and NodeBoard is an ascendent for EmptyWindow so with delete also fires keyUp for NodeBoard
`if (stage != null && stage.getKeyboardFocus() == null) {
            stage.setKeyboardFocus(this);
        }`
        
 For the fix I add check SharedResources.stage.getKeyboardFocus() == null in Empty window draw but not sure about this solution
   
   
    