### PR TITLE
Temporary fix for hierarchy app root node.

### DIFF
--- a/editor/src/com/talosvfx/talos/editor/project2/apps/SceneHierarchyApp.java
+++ b/editor/src/com/talosvfx/talos/editor/project2/apps/SceneHierarchyApp.java
@@ -91,6 +91,13 @@ public class SceneHierarchyApp extends AppManager.BaseApp<Scene> implements Game
 	@Override
 	public void applyFromPreferences(HierarchyPreference prefs) {
 		hierarchyWidget.getTree().collapseAll();
+
+		// stupid hack
+		// TODO: 12.01.23 fix so root is not generated everytime
+		if (prefs.isRootOpen()) {
+			hierarchyWidget.getTree().getRootNodes().first().setExpanded(true);
+		}
+
 		Array<String> expandedUUIDs = prefs.getUUUIDsOfExpandedObjects();
 		Array<GameObject> expandedGameObjects = new Array<>();
 		GameObjectContainer container = gameAsset.getResource();
@@ -122,6 +129,11 @@ public class SceneHierarchyApp extends AppManager.BaseApp<Scene> implements Game
 		}
 		HierarchyPreference preference = new HierarchyPreference();
 		preference.setUUUIDsOfExpandedObjects(expandedUUIDS);
+
+		// stupid hack
+		// TODO: 12.01.23 fix so root is not generated everytime
+		preference.setRootOpen(hierarchyWidget.getTree().getRootNodes().first().isExpanded());
+
 		return preference;
 	}
 }

--- a/editor/src/com/talosvfx/talos/editor/project2/apps/preferences/HierarchyPreference.java
+++ b/editor/src/com/talosvfx/talos/editor/project2/apps/preferences/HierarchyPreference.java
@@ -5,5 +5,10 @@ import lombok.Data;
 
 @Data
 public class HierarchyPreference implements AppPrefs.AppPreference {
+    // hack for now, because new root node is generated every time with different uuid and serialization
+    // doesn't really help :/
+    // TODO: 12.01.23 get rid off flag
+    boolean rootOpen;
+
     Array<String> UUUIDsOfExpandedObjects;
 }


### PR DESCRIPTION
Because root node of hierarchy widget is generated with new uuid  everytime, it was not in the list of expanded node and sometimes everything would be collapsed.