### PR TITLE
Selection bug from hierarchy widget.

### DIFF
--- a/editor/src/com/talosvfx/talos/editor/addons/scene/events/scene/AddToSelectionEvent.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/events/scene/AddToSelectionEvent.java
@@ -1,13 +1,25 @@
 package com.talosvfx.talos.editor.addons.scene.events.scene;
 
 import com.talosvfx.talos.editor.addons.scene.logic.GameObject;
+import com.talosvfx.talos.editor.addons.scene.logic.GameObjectContainer;
+import com.talosvfx.talos.editor.notifications.ContextRequiredEvent;
 import com.talosvfx.talos.editor.notifications.TalosEvent;
 import lombok.Data;
 
-@Data
-public class AddToSelectionEvent implements TalosEvent {
+public class AddToSelectionEvent extends ContextRequiredEvent<GameObjectContainer> {
 
 	private GameObject gameObject;
+
+	public AddToSelectionEvent set (GameObjectContainer context, GameObject gameObject) {
+		setContext(context);
+		this.gameObject = gameObject;
+
+		return this;
+	}
+
+	public GameObject getGameObject () {
+		return gameObject;
+	}
 
 	@Override
 	public void reset () {

--- a/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/HierarchyWidget.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/HierarchyWidget.java
@@ -96,7 +96,7 @@ public class HierarchyWidget extends Table implements Observer, EventContextProv
                 GameObject gameObject = objectMap.get(node.getObject().uuid.toString());
 
                 AddToSelectionEvent addToSelectionEvent = Notifications.obtainEvent(AddToSelectionEvent.class);
-                addToSelectionEvent.setGameObject(gameObject);
+                addToSelectionEvent.set(currentContainer, gameObject);
                 Notifications.fireEvent(addToSelectionEvent);
 
             }


### PR DESCRIPTION
Made the AddToSelectionEvent to be context based, so when selecting multiple entities from HierarchyWIdget only the correct scene will display the selection.