### PR TITLE
Crush when painting on fresh paintable surface.

### DIFF
--- a/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/gizmos/PaintSurfaceGizmo.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/gizmos/PaintSurfaceGizmo.java
@@ -173,6 +173,10 @@ public class PaintSurfaceGizmo extends Gizmo {
     }
 
     private FrameBuffer createFrameBuffer() {
+        if (frameBuffer != null) {
+            frameBuffer.dispose();
+        }
+
         PaintSurfaceComponent surface = gameObject.getComponent(PaintSurfaceComponent.class);
         GameAsset<Texture> gameResource = surface.getGameResource();
         if (gameResource.isBroken()) {

--- a/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/gizmos/PaintSurfaceGizmo.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/gizmos/PaintSurfaceGizmo.java
@@ -17,6 +17,7 @@ import com.badlogic.gdx.utils.ScreenUtils;
 import com.badlogic.gdx.utils.viewport.FitViewport;
 import com.badlogic.gdx.utils.viewport.Viewport;
 import com.talosvfx.talos.TalosMain;
+import com.talosvfx.talos.editor.addons.scene.assets.GameAsset;
 import com.talosvfx.talos.editor.addons.scene.logic.components.PaintSurfaceComponent;
 import com.talosvfx.talos.editor.addons.scene.logic.components.TransformComponent;
 import com.talosvfx.talos.editor.addons.scene.widgets.PaintToolsPane;
@@ -148,8 +149,12 @@ public class PaintSurfaceGizmo extends Gizmo {
             }
         }
 
-        if(frameBuffer == null || sizeIsDifferent) {
-            createFrameBuffer();
+        if (frameBuffer == null || sizeIsDifferent) {
+           FrameBuffer fbo = createFrameBuffer();
+           if (fbo == null) {
+               // framebuffer creation was unsuccessful, skip
+               return;
+           }
         }
 
         drawBrushToBuffer();
@@ -157,7 +162,9 @@ public class PaintSurfaceGizmo extends Gizmo {
 
     @Override
     public void touchDragged(float x, float y) {
-        drawBrushToBuffer();
+        if (frameBuffer != null) {
+            drawBrushToBuffer();
+        }
     }
 
     @Override
@@ -165,9 +172,14 @@ public class PaintSurfaceGizmo extends Gizmo {
 
     }
 
-    private void createFrameBuffer() {
+    private FrameBuffer createFrameBuffer() {
         PaintSurfaceComponent surface = gameObject.getComponent(PaintSurfaceComponent.class);
-        Texture resource = surface.getGameResource().getResource();
+        GameAsset<Texture> gameResource = surface.getGameResource();
+        if (gameResource.isBroken()) {
+            // no texture is assigned to the surface,skip
+            return null;
+        }
+        Texture resource = gameResource.getResource();
         resource.setFilter(Texture.TextureFilter.Nearest, Texture.TextureFilter.Nearest);
         frameBuffer = new FrameBuffer(Pixmap.Format.RGBA8888, resource.getWidth(), resource.getHeight(), false);
 
@@ -191,6 +203,8 @@ public class PaintSurfaceGizmo extends Gizmo {
         frameBuffer.end();
         Gdx.gl.glEnable(GL20.GL_BLEND);
         innerBatch.enableBlending();
+
+        return frameBuffer;
     }
 
     private void createBrushTexture() {


### PR DESCRIPTION
Fresh paintable surface does not have texture assigned to it, therefore it crushes when it tries to make FrameBuffer with null texture.