### PR TITLE
Routine camera lock fix.

### DIFF
--- a/editor/src/com/talosvfx/talos/editor/addons/scene/apps/routines/RoutineStage.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/apps/routines/RoutineStage.java
@@ -49,6 +49,7 @@ public class RoutineStage extends DynamicNodeStage<RoutineStageData> implements 
     private boolean playing;
     private ScenePreviewApp scenePreviewApp;
 
+    private boolean cameraLocked = false;
 
     public RoutineStage (RoutineEditorApp routineEditorApp, Skin skin) {
         super(skin);
@@ -320,6 +321,7 @@ public class RoutineStage extends DynamicNodeStage<RoutineStageData> implements 
 
             if(result) {
                 playing = true;
+                lockCamera(cameraLocked);
             }
         }
     }
@@ -358,6 +360,7 @@ public class RoutineStage extends DynamicNodeStage<RoutineStageData> implements 
     }
 
     public void lockCamera(boolean checked) {
+        cameraLocked = checked;
         if(scenePreviewApp != null) {
             scenePreviewApp.setLockCamera(checked);
         }


### PR DESCRIPTION
First time playing the routine now locks camera in preview, in case lock button was pressed in controls.