### PR TITLE
Project explorer fixes.

### DIFF
--- a/editor/src/com/talosvfx/talos/editor/addons/scene/assets/AssetRepository.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/assets/AssetRepository.java
@@ -27,6 +27,7 @@ import com.esotericsoftware.spine.SkeletonBinary;
 import com.esotericsoftware.spine.SkeletonData;
 import com.talosvfx.talos.editor.addons.scene.events.*;
 import com.talosvfx.talos.editor.addons.scene.events.meta.MetaDataReloadedEvent;
+import com.talosvfx.talos.editor.addons.scene.events.explorer.DirectoryMovedEvent;
 import com.talosvfx.talos.runtime.assets.AMetadata;
 import com.talosvfx.talos.editor.addons.scene.utils.importers.AssetImporter;
 import com.talosvfx.talos.editor.data.RoutineStageData;
@@ -1587,6 +1588,7 @@ public class AssetRepository extends BaseAssetRepository implements Observer {
 			populateChildren(file, rootNode);
 
 			file.moveTo(destination);
+			Notifications.fireEvent(Notifications.obtainEvent(DirectoryMovedEvent.class).set(file, destination));
 
 			updateChildReferences(rootNode);
 

--- a/editor/src/com/talosvfx/talos/editor/addons/scene/events/explorer/DirectoryMovedEvent.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/events/explorer/DirectoryMovedEvent.java
@@ -1,0 +1,25 @@
+package com.talosvfx.talos.editor.addons.scene.events.explorer;
+
+import com.badlogic.gdx.files.FileHandle;
+import com.talosvfx.talos.editor.notifications.TalosEvent;
+import lombok.Getter;
+
+public class DirectoryMovedEvent implements TalosEvent {
+
+    @Getter
+    private FileHandle oldHandle;
+    @Getter
+    private FileHandle newHandle;
+
+    public DirectoryMovedEvent set (FileHandle oldHandle, FileHandle newHandle) {
+        this.oldHandle = oldHandle;
+        this.newHandle = newHandle;
+        return this;
+    }
+
+    @Override
+    public void reset() {
+        oldHandle = null;
+        newHandle = null;
+    }
+}

--- a/editor/src/com/talosvfx/talos/editor/addons/scene/utils/importers/AssetImporter.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/utils/importers/AssetImporter.java
@@ -291,11 +291,9 @@ public class AssetImporter {
     }
 
     public static void moveFile(FileHandle file, FileHandle directory, boolean checkGameAssets, boolean rename) {
+        //Are we moving the actual scene editing?
 
-        //Are we moving the actual scene editting?
-
-
-        logger.info("Rdo scene editing move");
+        logger.info("Redo scene editing move");
 //        String path = SceneEditorWorkspace.getInstance().getCurrentContainer().path;
 //        if (file.path().equals(path)) {
 //            //moving the scene that we are editing
@@ -309,13 +307,6 @@ public class AssetImporter {
 //        }
 
         AssetRepository.getInstance().moveFile(file, directory, checkGameAssets, rename);
-
-
-        logger.info("file moved, we should send events so project explorer etc can change if they want to");
-
-//        SceneEditorAddon.get().projectExplorer.loadDirectoryTree(projectPath);
-//
-//        SceneEditorAddon.get().projectExplorer.select(directory.path());
     }
 
     public static FileHandle renameFile(FileHandle file, String newName) {

--- a/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/ProjectExplorerWidget.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/ProjectExplorerWidget.java
@@ -16,6 +16,7 @@ import com.kotcrab.vis.ui.widget.MenuItem;
 import com.kotcrab.vis.ui.widget.PopupMenu;
 import com.talosvfx.talos.editor.addons.scene.assets.AssetRepository;
 import com.talosvfx.talos.editor.addons.scene.events.AssetColorFillEvent;
+import com.talosvfx.talos.editor.addons.scene.events.explorer.DirectoryMovedEvent;
 import com.talosvfx.talos.editor.addons.scene.utils.importers.AssetImporter;
 import com.talosvfx.talos.editor.addons.scene.widgets.directoryview.DirectoryViewWidget;
 import com.talosvfx.talos.editor.addons.scene.widgets.directoryview.KeepStopReplaceDialog;
@@ -159,14 +160,16 @@ public class ProjectExplorerWidget extends Table implements Observer {
                     String parentPath = parentToMoveTo.getObject();
                     String childPath = childThatHasMoved.getObject();
 
-                    System.out.println("Moving " + childPath + " " + " to " + parentPath);
-
                     FileHandle parentHandle = Gdx.files.absolute(parentPath);
                     FileHandle childHandle = Gdx.files.absolute(childPath);
+                    if (childHandle.parent().equals(parentHandle)) {
+                        // do not need to move, when rearranging in the same directory
+                        return;
+                    }
 
+                    System.out.println("Moving " + childPath + " " + " to " + parentPath);
 
                     //Its always folders
-
                     AssetRepository.getInstance().moveFile(childHandle, parentHandle, false);
 
                 }
@@ -793,6 +796,12 @@ public class ProjectExplorerWidget extends Table implements Observer {
     @EventHandler
     public void onAssetColorFillEvent (AssetColorFillEvent event) {
         directoryViewWidget.changeAssetPreview(event.getFileHandle());
+    }
+
+    @EventHandler
+    public void onDirectoryMovedEvent (DirectoryMovedEvent event) {
+        loadDirectoryTree(rootNode.getObject());
+        select(event.getNewHandle().path());
     }
 
     public void showYesNoDialog (String title, String message, Runnable yes, Runnable no) {

--- a/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/directoryview/DirectoryViewWidget.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/directoryview/DirectoryViewWidget.java
@@ -196,20 +196,22 @@ public class DirectoryViewWidget extends Table {
 					}
 				}
 			} else if (selected.size > 1) {
-				ObjectSet<AMetadata> list = new ObjectSet<AMetadata>();
+				ObjectSet<IPropertyHolder> list = new ObjectSet<>();
 				for (int i = 0; i < selected.size; i++) {
 					Item item = selected.get(i);
 					if (item.gameAsset != null) {
 						if (!item.gameAsset.isBroken()) {
 							RawAsset rootRawAsset = item.gameAsset.getRootRawAsset();
-							list.add(rootRawAsset.metaData);
+							AMetadata metaData = rootRawAsset.metaData;
+							IPropertyHolder holderForMeta = PropertyWrapperProviders.getOrCreateHolder(metaData);
+							list.add(holderForMeta);
 						}
 					}
 				}
 				if (list.isEmpty()) {
 					holder = null;
 				} else {
-					holder = new MultiPropertyHolder(list);
+					holder = new MultiPropertyHolder<>(list);
 				}
 			}
 


### PR DESCRIPTION
Crash fix, when moving directory from tree view. AssetRepository properly fires event after moving directory for tree view to update its state.
Prohibit move call from tree view in cases moving file into the same folder.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203719350653506