### PR TITLE
A lot of fixes for directory view.

### DIFF
--- a/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/ProjectExplorerWidget.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/ProjectExplorerWidget.java
@@ -179,7 +179,6 @@ public class ProjectExplorerWidget extends Table implements Observer {
             @Override
             public void selected (FilteredTree.Node node) {
                 select(node);
-                directoryViewWidget.openDirectory((String) node.getObject());
             }
 
             @Override
@@ -624,8 +623,6 @@ public class ProjectExplorerWidget extends Table implements Observer {
         rootNode.setExpanded(true);
 
         rootNode.expandAll();
-
-        directoryViewWidget.openDirectory(root.path());
     }
 
     private void traversePath(FileHandle path, int currDepth, int maxDepth, FilteredTree.Node node) {

--- a/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/directoryview/DirectoryViewWidget.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/directoryview/DirectoryViewWidget.java
@@ -507,11 +507,12 @@ public class DirectoryViewWidget extends Table {
 					target = fileHandle;
 				}
 
-				if (belongsToProject(payloadObject)) { // should move file
-					handlePayloadDropToDirectory(payloadObject, target, false);
-				} else { // should copy file
+				if (payloadObject.isExternal()) { // should copy file
 					handlePayloadDropToDirectory(payloadObject, target, true);
+				} else { // should move file
+					handlePayloadDropToDirectory(payloadObject, target, false);
 				}
+
 			}
 
 			/**
@@ -655,62 +656,6 @@ public class DirectoryViewWidget extends Table {
 			return false;
 		}
 		return item.fileHandle.isDirectory();
-	}
-
-	/**
-	 * Broken assets still belong to project.
-	 */
-	private static boolean belongsToProject (GlobalDragAndDrop.BaseDragAndDropPayload payload) {
-		if (payload instanceof GlobalDragAndDrop.FileHandleDragAndDropPayload) {
-			return belongsToProject((GlobalDragAndDrop.FileHandleDragAndDropPayload) payload);
-		} else if (payload instanceof GlobalDragAndDrop.GameAssetDragAndDropPayload) {
-			return belongsToProject((GlobalDragAndDrop.GameAssetDragAndDropPayload) payload);
-		} else if (payload instanceof GlobalDragAndDrop.ArrayDragAndDropPayload) {
-			return belongToProject((GlobalDragAndDrop.ArrayDragAndDropPayload) payload);
-		}
-		return false;
-	}
-
-	/**
-	 * Broken assets still belong to project.
-	 */
-	private static boolean belongsToProject (GlobalDragAndDrop.FileHandleDragAndDropPayload payload) {
-		if (payload == null || payload.getHandle() == null) {
-			return false;
-		}
-		String projectPath = SharedResources.currentProject.rootProjectDir().path();
-		String payloadPath = payload.getHandle().path();
-		return payloadPath.startsWith(projectPath);
-	}
-
-	/**
-	 * Broken assets still belong to project.
-	 */
-	private static boolean belongsToProject (GlobalDragAndDrop.GameAssetDragAndDropPayload payload) {
-		if (payload == null || payload.getGameAsset() == null) {
-			return false;
-		}
-		String projectPath = SharedResources.currentProject.rootProjectDir().path();
-		String payloadPath = payload.getGameAsset().getRootRawAsset().handle.path();
-		return payloadPath.startsWith(projectPath);
-	}
-
-	/**
-	 * Broken assets still belong to project.
-	 * In case even single file/asset doesn't belong to project, will return false.
-	 */
-	private static boolean belongToProject (GlobalDragAndDrop.ArrayDragAndDropPayload payload) {
-		boolean belongsToProject = true;
-
-		for (GlobalDragAndDrop.BaseDragAndDropPayload item : payload.getItems()) {
-			if (item instanceof GlobalDragAndDrop.FileHandleDragAndDropPayload && !belongsToProject((GlobalDragAndDrop.FileHandleDragAndDropPayload) item)) {
-				return false;
-			} else if (item instanceof GlobalDragAndDrop.GameAssetDragAndDropPayload && !belongsToProject((GlobalDragAndDrop.GameAssetDragAndDropPayload) item)) {
-				return false;
-			}
-		}
-
-		return belongsToProject;
 	}
 
 	private void itemClicked (Item item, boolean rightClick) {

--- a/editor/src/com/talosvfx/talos/editor/project2/GlobalDragAndDrop.java
+++ b/editor/src/com/talosvfx/talos/editor/project2/GlobalDragAndDrop.java
@@ -16,6 +16,7 @@ import com.badlogic.gdx.utils.Pools;
 import com.talosvfx.talos.runtime.assets.GameAsset;
 import com.talosvfx.talos.editor.widgets.ui.ActorCloneable;
 import lombok.Data;
+import lombok.Getter;
 
 public class GlobalDragAndDrop {
 
@@ -79,10 +80,14 @@ public class GlobalDragAndDrop {
 
 	public void fakeDragDrop (int screenX, int screenY, String[] absoluteFiles) {
 		ArrayDragAndDropPayload arrayDragAndDropPayload = new ArrayDragAndDropPayload();
+		arrayDragAndDropPayload.isExternal = true;
+
 		Array<BaseDragAndDropPayload> items = arrayDragAndDropPayload.getItems();
 		for (String absoluteFileHandle : absoluteFiles) {
 			FileHandle absolute = Gdx.files.absolute(absoluteFileHandle);
-			items.add(new FileHandleDragAndDropPayload(absolute));
+			FileHandleDragAndDropPayload fileHandleDragAndDropPayload = new FileHandleDragAndDropPayload(absolute);
+			fileHandleDragAndDropPayload.isExternal = true;
+			items.add(fileHandleDragAndDropPayload);
 		}
 
 		Table dummyActor = new Table();
@@ -144,9 +149,8 @@ public class GlobalDragAndDrop {
 	}
 
 	public static class BaseDragAndDropPayload {
-
-		public BaseDragAndDropPayload () {
-		}
+		@Getter
+		protected boolean isExternal;
 	}
 
 	@Data


### PR DESCRIPTION
1. Directory view would open folder twice, when selecting it from directory tree widget.
2. Loading directory tree would open folder in directory view second time, although those action should not be related.
3. Bugfix, dropping file from native file manager into directory view would copy the file, however dropping(hitting) file from native file manager into directory item inside directory view would move it instead ( file would be removed from source path )
4. Bugfix, when dropping name.ext into directory, which already had a file with same name would replace without permission of user. New behaviour, asks user if they want to replace, keep or stop the operation.
5. Enhancement, when dropping multiple files would update the view per file. New behaviour, updates the view only on the last file upload. Upload is synchronised in case some files wait for dialog confirmation to get uploaded/moved.
6. Adjustment. Before, when moving file into target directory, directory view would also navigate to that target. New behaviour, directory view will stay in the same direction.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203751132365331