### PR TITLE
Do not open context menu, when no folder is open in directory view.

### DIFF
--- a/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/directoryview/DirectoryViewWidget.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/directoryview/DirectoryViewWidget.java
@@ -80,10 +80,11 @@ public class DirectoryViewWidget extends Table {
 				if (!event.isStopped()) {
 					clearSelection();
 
-					Array<FileHandle> selection = new Array<>();
-					selection.add(fileHandle);
-
-					projectExplorerWidget.showContextMenu(selection, true);
+					if (fileHandle != null) {
+						Array<FileHandle> selection = new Array<>();
+						selection.add(fileHandle);
+						projectExplorerWidget.showContextMenu(selection, true);
+					}
 					event.stop();
 				}
 			}


### PR DESCRIPTION
Crash fix, do not open context menu, when no folder is open in directory view. 