### PR TITLE
Crash after pivot click

### DIFF
--- a/editor/src/com/talosvfx/talos/editor/wrappers/AttractorModuleWrapper.java
+++ b/editor/src/com/talosvfx/talos/editor/wrappers/AttractorModuleWrapper.java
@@ -2,10 +2,7 @@ package com.talosvfx.talos.editor.wrappers;
 
 import com.talosvfx.talos.TalosMain;
 import com.talosvfx.talos.runtime.vfx.Slot;
-import com.talosvfx.talos.runtime.vfx.modules.AbstractModule;
-import com.talosvfx.talos.runtime.vfx.modules.AttractorModule;
-import com.talosvfx.talos.runtime.vfx.modules.InterpolationModule;
-import com.talosvfx.talos.runtime.vfx.modules.RandomRangeModule;
+import com.talosvfx.talos.runtime.vfx.modules.*;
 
 public class AttractorModuleWrapper extends ModuleWrapper<AttractorModule> {
 
@@ -26,7 +23,7 @@ public class AttractorModuleWrapper extends ModuleWrapper<AttractorModule> {
 
         if(slot.getIndex() == AttractorModule.INITIAL_ANGLE) return RandomRangeModule.class;
         if(slot.getIndex() == AttractorModule.INITIAL_VELOCITY) return RandomRangeModule.class;
-        if(slot.getIndex() == AttractorModule.ATTRACTOR_POSITION) return TalosMain.Instance().UIStage().getPreferred3DVectorClass();;
+        if(slot.getIndex() == AttractorModule.ATTRACTOR_POSITION) return Vector3Module.class;
         if(slot.getIndex() == AttractorModule.ALPHA) return InterpolationModule.class;
         return null;
     }

--- a/editor/src/com/talosvfx/talos/editor/wrappers/FromToModuleWrapper.java
+++ b/editor/src/com/talosvfx/talos/editor/wrappers/FromToModuleWrapper.java
@@ -30,6 +30,7 @@ import com.talosvfx.talos.runtime.vfx.Slot;
 
 import com.talosvfx.talos.runtime.vfx.modules.AbstractModule;
 import com.talosvfx.talos.runtime.vfx.modules.FromToModule;
+import com.talosvfx.talos.runtime.vfx.modules.Vector3Module;
 
 public class FromToModuleWrapper extends ModuleWrapper<FromToModule> implements IDragPointProvider {
 
@@ -122,8 +123,8 @@ public class FromToModuleWrapper extends ModuleWrapper<FromToModule> implements 
     @Override
     public Class<? extends AbstractModule>  getSlotsPreferredModule(Slot slot) {
 
-        if(slot.getIndex() == FromToModule.FROM) return TalosMain.Instance().UIStage().getPreferred3DVectorClass();;
-        if(slot.getIndex() == FromToModule.TO) return TalosMain.Instance().UIStage().getPreferred3DVectorClass();;
+        if(slot.getIndex() == FromToModule.FROM) return Vector3Module.class;
+        if(slot.getIndex() == FromToModule.TO) return Vector3Module.class;
 
         return null;
     }

--- a/editor/src/com/talosvfx/talos/editor/wrappers/ParticleModuleWrapper.java
+++ b/editor/src/com/talosvfx/talos/editor/wrappers/ParticleModuleWrapper.java
@@ -19,11 +19,7 @@ package com.talosvfx.talos.editor.wrappers;
 import com.talosvfx.talos.TalosMain;
 import com.talosvfx.talos.runtime.vfx.Slot;
 
-import com.talosvfx.talos.runtime.vfx.modules.AbstractModule;
-import com.talosvfx.talos.runtime.vfx.modules.CurveModule;
-import com.talosvfx.talos.runtime.vfx.modules.GradientColorModule;
-import com.talosvfx.talos.runtime.vfx.modules.ParticleModule;
-import com.talosvfx.talos.runtime.vfx.modules.StaticValueModule;
+import com.talosvfx.talos.runtime.vfx.modules.*;
 
 public class ParticleModuleWrapper extends ModuleWrapper<ParticleModule> {
 
@@ -79,7 +75,7 @@ public class ParticleModuleWrapper extends ModuleWrapper<ParticleModule> {
     public Class<? extends AbstractModule>  getSlotsPreferredModule(Slot slot) {
 
         if(slot.getIndex() == ParticleModule.LIFE) return StaticValueModule.class;
-        if(slot.getIndex() == ParticleModule.PIVOT) TalosMain.Instance().UIStage().getPreferred3DVectorClass();
+        if(slot.getIndex() == ParticleModule.PIVOT) return Vector3Module.class;
         if(slot.getIndex() == ParticleModule.COLOR) return GradientColorModule.class;
         if(slot.getIndex() == ParticleModule.TRANSPARENCY) return CurveModule.class;
 

--- a/editor/src/com/talosvfx/talos/editor/wrappers/TargetModuleWrapper.java
+++ b/editor/src/com/talosvfx/talos/editor/wrappers/TargetModuleWrapper.java
@@ -13,6 +13,7 @@ import com.talosvfx.talos.editor.widgets.ui.PreviewWidget;
 import com.talosvfx.talos.runtime.vfx.Slot;
 import com.talosvfx.talos.runtime.vfx.modules.AbstractModule;
 import com.talosvfx.talos.runtime.vfx.modules.TargetModule;
+import com.talosvfx.talos.runtime.vfx.modules.Vector3Module;
 
 public class TargetModuleWrapper extends ModuleWrapper<TargetModule> implements IDragPointProvider {
 
@@ -95,8 +96,8 @@ public class TargetModuleWrapper extends ModuleWrapper<TargetModule> implements 
     @Override
     public Class<? extends AbstractModule>  getSlotsPreferredModule(Slot slot) {
 
-        if(slot.getIndex() == TargetModule.FROM) return TalosMain.Instance().UIStage().getPreferred3DVectorClass();;
-        if(slot.getIndex() == TargetModule.TO) return TalosMain.Instance().UIStage().getPreferred3DVectorClass();;
+        if(slot.getIndex() == TargetModule.FROM) return Vector3Module.class;
+        if(slot.getIndex() == TargetModule.TO) return Vector3Module.class;
 
         return null;
     }


### PR DESCRIPTION
Crash after clicking on the pivot from particle node

changed getPreferred3DVectorClass() calls to Vector3Module.class