### PR TITLE
routine controls bugs for multiple executors

### DIFF
--- a/editor/src/com/talosvfx/talos/editor/addons/scene/apps/routines/ScenePreviewStage.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/apps/routines/ScenePreviewStage.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.g2d.PolygonBatch;
+import com.badlogic.gdx.utils.Array;
 import com.talosvfx.talos.editor.addons.scene.MainRenderer;
 
 import com.talosvfx.talos.editor.project2.AppManager;
@@ -44,6 +45,8 @@ public class ScenePreviewStage extends ViewportWidget implements Observer {
 
 	@Setter@Getter
 	private boolean paused =false;
+
+	@Getter
 	private boolean lockCamera = false;
 
 	public ScenePreviewStage () {
@@ -130,6 +133,14 @@ public class ScenePreviewStage extends ViewportWidget implements Observer {
 			scene.load(TempHackUtil.hackIt(currentContainer.getAsString()));
 
 			currentScene = scene;
+
+			Array<GameObject> cameraGoList = currentScene.root.getChildrenByComponent(CameraComponent.class, new Array<>());
+			if(cameraGoList != null && !cameraGoList.isEmpty()) {
+				cameraGO = cameraGoList.first();
+			} else {
+				cameraGO = null;
+			}
+			setCameraGO(cameraGO);
 		}
 	}
 

--- a/editor/src/com/talosvfx/talos/editor/addons/scene/apps/routines/nodes/RoutineExecuteNodeWidget.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/apps/routines/nodes/RoutineExecuteNodeWidget.java
@@ -58,14 +58,6 @@ public class RoutineExecuteNodeWidget extends AbstractRoutineNodeWidget {
         if(sceneAsset != null && sceneAsset.type == GameAssetType.SCENE) {
             ScenePreviewApp scenePreviewApp = nodeStage.openPreviewWindow(sceneAsset);
             scenePreviewApp.reload();
-            container = scenePreviewApp.getWorkspaceWidget().currentScene;
-            Array<GameObject> cameraGoList = container.root.getChildrenByComponent(CameraComponent.class, new Array<>());
-            if(cameraGoList != null && !cameraGoList.isEmpty()) {
-                cameraGO = cameraGoList.first();
-            } else {
-                cameraGO = null;
-            }
-            scenePreviewApp.getWorkspaceWidget().setCameraGO(cameraGO);
         } else {
             return false;
         }

--- a/editor/src/com/talosvfx/talos/editor/addons/scene/apps/routines/ui/RoutineControlWindow.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/apps/routines/ui/RoutineControlWindow.java
@@ -11,6 +11,7 @@ import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.badlogic.gdx.utils.Array;
 import com.talosvfx.talos.editor.addons.scene.apps.routines.RoutineStage;
+import com.talosvfx.talos.editor.project2.apps.ScenePreviewApp;
 import com.talosvfx.talos.runtime.routine.RoutineInstance;
 import com.talosvfx.talos.editor.data.RoutineStageData;
 import com.talosvfx.talos.editor.nodes.widgets.ValueWidget;
@@ -119,6 +120,43 @@ public class RoutineControlWindow extends Table {
                 routineStage.lockCamera(cameraLockBtn.isChecked());
             }
         });
+
+        selectBox.addListener(new ChangeListener() {
+            @Override
+            public void changed(ChangeEvent event, Actor actor) {
+                String executorName = selectBox.getSelected().toString();
+                routineStage.setCurrentScenePreviewApp(executorName);
+
+                ScenePreviewApp currentScenePreviewApp = routineStage.getCurrentScenePreviewApp();
+                if (currentScenePreviewApp != null) {
+                    cameraLockBtn.setChecked(currentScenePreviewApp.getWorkspaceWidget().isLockCamera());
+
+                    if (routineStage.isPlaying()) {
+                        routineStage.stop();
+                        updatePlayState();
+                    }
+
+                    if(currentScenePreviewApp.getWorkspaceWidget().isPaused()){
+                        routineStage.pause();
+                    }else{
+                        routineStage.resume();
+                    }
+                    updatePauseState();
+                } else {
+                   reset();
+                }
+            }
+        });
+    }
+
+    public void reset(){
+        cameraLockBtn.setChecked(false);
+        if (routineStage.isPlaying()) {
+            routineStage.stop();
+            updatePlayState();
+        }
+        routineStage.resume();
+        updatePauseState();
     }
 
     private void updatePauseState() {

--- a/editor/src/com/talosvfx/talos/editor/addons/scene/assets/AssetRepository.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/assets/AssetRepository.java
@@ -331,7 +331,6 @@ public class AssetRepository extends BaseAssetRepository implements Observer {
 	private void checkAllGameAssetCreation () { //raws
 		checkGameAssetCreation(GameAssetType.SPRITE);
 		checkGameAssetCreation(GameAssetType.SCRIPT);
-		checkGameAssetCreation(GameAssetType.ROUTINE);
 		checkGameAssetCreation(GameAssetType.ATLAS);
 		checkGameAssetCreation(GameAssetType.SOUND);
 
@@ -341,6 +340,7 @@ public class AssetRepository extends BaseAssetRepository implements Observer {
 		checkGameAssetCreation(GameAssetType.VFX_OUTPUT);
 		checkGameAssetCreation(GameAssetType.PREFAB);
 		checkGameAssetCreation(GameAssetType.SCENE);
+		checkGameAssetCreation(GameAssetType.ROUTINE);
 
 		checkGameAssetCreation(GameAssetType.TILE_PALETTE);
 

--- a/editor/src/com/talosvfx/talos/editor/notifications/events/LayoutLoadedEvent.java
+++ b/editor/src/com/talosvfx/talos/editor/notifications/events/LayoutLoadedEvent.java
@@ -1,0 +1,10 @@
+package com.talosvfx.talos.editor.notifications.events;
+
+import com.talosvfx.talos.editor.notifications.TalosEvent;
+
+public class LayoutLoadedEvent implements TalosEvent {
+    @Override
+    public void reset() {
+
+    }
+}

--- a/editor/src/com/talosvfx/talos/editor/project2/AppManager.java
+++ b/editor/src/com/talosvfx/talos/editor/project2/AppManager.java
@@ -316,6 +316,14 @@ public class AppManager extends InputAdapter implements Observer {
 	}
 
 	public <T, U extends BaseApp<T>> U openAppIfNotOpened (GameAsset<T> asset, Class<U> app) {
+		U openedApp = getAppIfOpened(asset, app);
+		if (openedApp != null) {
+			return openedApp;
+		}
+		return openApp(asset, app);
+	}
+
+	public <T, U extends BaseApp<T>> U getAppIfOpened(GameAsset<T> asset, Class<U> app) {
 		Array<? extends BaseApp<?>> baseApps = baseAppsOpenForGameAsset.get(asset);
 		for (BaseApp<?> baseApp : baseApps) {
 			if(baseApp.getClass().equals(app)) {
@@ -325,8 +333,7 @@ public class AppManager extends InputAdapter implements Observer {
 				return (U) baseApp;
 			}
 		}
-
-		return openApp(asset, app);
+		return null;
 	}
 
 

--- a/editor/src/com/talosvfx/talos/editor/project2/TalosProjectData.java
+++ b/editor/src/com/talosvfx/talos/editor/project2/TalosProjectData.java
@@ -8,6 +8,8 @@ import com.badlogic.gdx.utils.JsonValue;
 import com.badlogic.gdx.utils.JsonWriter;
 import com.talosvfx.talos.editor.addons.scene.assets.AssetRepository;
 import com.talosvfx.talos.editor.layouts.LayoutGrid;
+import com.talosvfx.talos.editor.notifications.Notifications;
+import com.talosvfx.talos.editor.notifications.events.LayoutLoadedEvent;
 import com.talosvfx.talos.editor.project2.apps.ProjectExplorerApp;
 import com.talosvfx.talos.editor.project2.localprefs.TalosLocalPrefs;
 import com.talosvfx.talos.runtime.scene.SceneData;
@@ -122,6 +124,7 @@ public class TalosProjectData implements Json.Serializable {
 		} else {
 			SharedResources.appManager.openApp(AppManager.singletonAsset, ProjectExplorerApp.class);
 		}
+		Notifications.fireEvent(Notifications.obtainEvent(LayoutLoadedEvent.class));
 	}
 
 	public FileHandle getProjectDir() {

--- a/runtimes/talos/src/main/java/com/talosvfx/talos/runtime/routine/nodes/RoutineExecutorNode.java
+++ b/runtimes/talos/src/main/java/com/talosvfx/talos/runtime/routine/nodes/RoutineExecutorNode.java
@@ -44,8 +44,8 @@ public class RoutineExecutorNode extends RoutineNode {
 
     @Override
     protected void configureNode(JsonValue properties) {
+        if(configured) return;
         super.configureNode(properties);
-        if(!configured) return;
 
         Object val = inputs.get("title").valueOverride;
         String title = val != null ? (String) val : "";


### PR DESCRIPTION
In RoutineStage added a map for multiple scenePreview 
when layout loading finished we check if there is opened scenePreviews and put in the map (Added Layout loaded event)
Every time when the user changes the executor in the controls widget  we set a new CurrentScenePreviewApp
