### PR TITLE
Layer delete bug

### DIFF
--- a/editor/src/com/talosvfx/talos/editor/addons/scene/logic/componentwrappers/MapComponentProvider.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/logic/componentwrappers/MapComponentProvider.java
@@ -72,6 +72,11 @@ public class MapComponentProvider extends RendererComponentProvider<MapComponent
 			public void onUpdate() {
 
 			}
+
+			@Override
+			public void onDeleteNode(TalosLayer talosLayer) {
+
+			}
 		});
 
 		talosLayerPropertiesWidget = new TalosLayerPropertiesWidget(null, new Supplier<TalosLayer>() {

--- a/editor/src/com/talosvfx/talos/editor/addons/scene/logic/componentwrappers/ScenePropertyProvider.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/logic/componentwrappers/ScenePropertyProvider.java
@@ -102,6 +102,16 @@ public class ScenePropertyProvider implements IPropertyProvider {
 				int preferredLayerIndex = SharedResources.currentProject.getSceneData().getPreferredSceneLayer().getIndex();
 				itemListWidget.list.addNodeToSelectionByIndex(preferredLayerIndex);
 			}
+
+			@Override
+			public void onDeleteNode(ItemData itemData) {
+				SceneData sceneData = SharedResources.currentProject.getSceneData();
+				if(itemData.text.equals(sceneData.getPreferredSceneLayer().getName())){
+					sceneData.setPreferredSceneLayer("Default");
+					int preferredLayerIndex = sceneData.getPreferredSceneLayer().getIndex();
+					itemListWidget.list.addNodeToSelectionByIndex(preferredLayerIndex);
+				}
+			}
 		});
 		itemListWidget.list.addItemListener(new FilteredTree.ItemListener<ItemData>() {
 			@Override

--- a/editor/src/com/talosvfx/talos/editor/widgets/propertyWidgets/DynamicItemListWidget.java
+++ b/editor/src/com/talosvfx/talos/editor/widgets/propertyWidgets/DynamicItemListWidget.java
@@ -31,6 +31,8 @@ public class DynamicItemListWidget<T> extends PropertyWidget<Array<T>> {
         String updateName (T t, String newText);
 
         void onUpdate();
+
+        void onDeleteNode(T t);
     }
 
 
@@ -157,6 +159,7 @@ public class DynamicItemListWidget<T> extends PropertyWidget<Array<T>> {
                     }
                 }
                 list.remove(selection.first());
+                interaction.onDeleteNode(selection.first().getObject());
                 rootNodes = list.getRootNodes();
                 if (rootNodes.size > 0) {
                     selection.clear();
@@ -164,7 +167,6 @@ public class DynamicItemListWidget<T> extends PropertyWidget<Array<T>> {
                     if (index < 0) index = 0;
                     selection.add(rootNodes.get(index));
                 }
-
                 callValueChanged(makeDataArray());
             }
         }


### PR DESCRIPTION
Crash after deleting the layer

app crashes because the deleted layer is preferred.

Added onDelete method in interaction. If the layer is preferred set it to default