### PR TITLE
HierarchyApp preference onSave exception fix.

### DIFF
--- a/editor/src/com/talosvfx/talos/editor/project2/apps/SceneHierarchyApp.java
+++ b/editor/src/com/talosvfx/talos/editor/project2/apps/SceneHierarchyApp.java
@@ -130,7 +130,9 @@ public class SceneHierarchyApp extends AppManager.BaseApp<Scene> implements Game
 
 		// stupid hack
 		// TODO: 12.01.23 fix so root is not generated everytime
-		preference.setRootOpen(hierarchyWidget.getTree().getRootNodes().first().isExpanded());
+		if (!hierarchyWidget.getTree().getRootNodes().isEmpty()) { // in case of dummy app no root node exists
+			preference.setRootOpen(hierarchyWidget.getTree().getRootNodes().first().isExpanded());
+		}
 
 		return preference;
 	}


### PR DESCRIPTION
Fix crash when saving dummy hierarchy app. Crash was happening, because dummy hierarchy app did not have any root node to save.