### PR TITLE
Sprite rename from propertye panel stackoverflow.

### DIFF
--- a/editor/src/com/talosvfx/talos/editor/widgets/propertyWidgets/EditableLabelWidget.java
+++ b/editor/src/com/talosvfx/talos/editor/widgets/propertyWidgets/EditableLabelWidget.java
@@ -32,7 +32,7 @@ public class EditableLabelWidget extends PropertyWidget<String> {
             public void keyboardFocusChanged (FocusEvent event, Actor actor, boolean focused) {
                 super.keyboardFocusChanged(event, actor, focused);
                 if (!focused) {
-                    propertyValue.finishTextEdit();
+                    propertyValue.finishTextEdit(true);
                 }
             }
         });


### PR DESCRIPTION
Skip notifying focus change, when finishing text edit for renaming GameObject from property panel.