### PR TITLE
Brush resize

### DIFF
--- a/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/gizmos/PaintSurfaceGizmo.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/gizmos/PaintSurfaceGizmo.java
@@ -69,6 +69,7 @@ public class PaintSurfaceGizmo extends Gizmo implements Observer, GameAsset.Game
             public boolean keyUp(InputEvent event, int keycode) {
                 if (keycode == Input.Keys.LEFT_BRACKET || keycode == Input.Keys.RIGHT_BRACKET) {
                     paintToolsPane.bracketUp(keycode);
+                    destroyBrushTexture();
                     return true;
                 }
 


### PR DESCRIPTION
Brush texture destroy old texture after key is up to remake new texture corresponding to new size.