### PR TITLE
Crash when removing asset tied to routine node, or exception paintable surface.

### DIFF
--- a/editor/src/com/talosvfx/talos/editor/nodes/widgets/GameAssetWidget.java
+++ b/editor/src/com/talosvfx/talos/editor/nodes/widgets/GameAssetWidget.java
@@ -142,7 +142,7 @@ public class GameAssetWidget<T> extends AbstractWidget<GameAsset<T>> implements 
     @Override
     public void write(Json json, String name) {
         json.writeObjectStart(name);
-        if(gameAsset != null) {
+        if(gameAsset != null && !gameAsset.isBroken()) {
             json.writeValue("type", type);
             json.writeValue("id", gameAsset.nameIdentifier);
             json.writeValue("uuid", gameAsset.getRootRawAsset().metaData.uuid.toString());

--- a/runtimes/talos/src/main/java/com/talosvfx/talos/runtime/scene/components/PaintSurfaceComponent.java
+++ b/runtimes/talos/src/main/java/com/talosvfx/talos/runtime/scene/components/PaintSurfaceComponent.java
@@ -83,6 +83,9 @@ public class PaintSurfaceComponent extends AComponent implements GameResourceOwn
 
     public void saveOnFile () {
         GameAsset<Texture> gameResource = getGameResource();
+        if (gameResource.isBroken()) {
+            return;
+        }
         FileHandle handle = gameResource.getRootRawAsset().handle;
 
         TextureData textureData = gameResource.getResource().getTextureData();


### PR DESCRIPTION
Select image for spawn sprite node and remove that image. Try to move the node, crash!
Try to save paintable surface component, when asset is missing, onSave throws an exception.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204164633195542