### PR TITLE
take camera preview take into account world position instead of local

### DIFF
--- a/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/CameraPreview.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/CameraPreview.java
@@ -52,7 +52,7 @@ public class CameraPreview extends Actor {
     public void act (float delta) {
         super.act(delta);
         TransformComponent transform = cameraObject.getComponent(TransformComponent.class);
-        viewport.getCamera().position.set(transform.position.x, transform.position.y, 0);
+        viewport.getCamera().position.set(transform.worldPosition.x, transform.worldPosition.y, 0);
         ((OrthographicCamera)viewport.getCamera()).zoom = component.zoom;
         OrthographicCamera camera = (OrthographicCamera) viewport.getCamera();
         float currRotation = getCameraAngle(camera);


### PR DESCRIPTION
when attaching camera to another game object as a child, it does  not take into account parent transform.