### PR TITLE
Bugfix: HierarchyWidget rename

### DIFF
--- a/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/HierarchyWidget.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/HierarchyWidget.java
@@ -643,6 +643,8 @@ public class HierarchyWidget extends Table implements Observer, EventContextProv
                 gameObjectNameChanged.newName = newText;
                 gameObjectNameChanged.oldName = oldName;
                 Notifications.fireEvent(gameObjectNameChanged);
+
+                SceneUtils.markContainerChanged(currentContainer);
             }
         });
 


### PR DESCRIPTION
When renaming GameObject from HierarchyWidget, the changes were not marked.