### PR TITLE
Bugfix: Remove GameObjects from hierarchy

### DIFF
--- a/editor/src/com/talosvfx/talos/editor/addons/scene/SceneEditorWorkspace.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/SceneEditorWorkspace.java
@@ -6,9 +6,7 @@ import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.OrthographicCamera;
-import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.PolygonBatch;
-import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas.AtlasRegion;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.badlogic.gdx.math.MathUtils;
@@ -29,7 +27,6 @@ import com.talosvfx.talos.editor.addons.scene.assets.AssetRepository;
 import com.talosvfx.talos.editor.addons.scene.logic.IPropertyHolder;
 import com.talosvfx.talos.editor.addons.scene.logic.MultiPropertyHolder;
 import com.talosvfx.talos.editor.addons.scene.logic.PropertyWrapperProviders;
-import com.talosvfx.talos.editor.addons.scene.widgets.gizmos.CurveGizmo;
 import com.talosvfx.talos.editor.widgets.ui.gizmos.GroupSelectionGizmo;
 import com.talosvfx.talos.runtime.RuntimeContext;
 import com.talosvfx.talos.runtime.assets.GameAsset;
@@ -543,7 +540,10 @@ public class SceneEditorWorkspace extends ViewportWidget implements Json.Seriali
 		ObjectSet<GameObject> deleteList = new ObjectSet<>();
 		deleteList.addAll(selection);
 		requestSelectionClear();
-		deleteGameObjects(deleteList);
+
+		if (currentContainer != null) {
+			SceneUtils.deleteGameObjects(currentContainer, deleteList);
+		}
 	}
 
 	public void escapePressed() {
@@ -1001,36 +1001,6 @@ public class SceneEditorWorkspace extends ViewportWidget implements Json.Seriali
 		if (gameObjects != null) {
 			for (int i = 0; i < gameObjects.size; i++) {
 				selectGameObjectAndChildren(gameObjects.get(i));
-			}
-		}
-	}
-
-	public void deleteGameObjects (ObjectSet<GameObject> gameObjects) {
-		if (currentContainer != null) {
-			for (GameObject gameObject : gameObjects) {
-
-				if (gameObject == null)
-					continue;
-
-				GameObject parent = gameObject.getParent();
-				if (parent != null) {
-
-					Array<GameObject> deletedObjects = null;
-
-					if (parent.hasGOWithName(gameObject.getName())) {
-						deletedObjects = parent.deleteGameObject(gameObject);
-					}
-
-					if (deletedObjects != null) {
-						for (GameObject deletedObject : deletedObjects) {
-							SceneUtils.deleteGameObject(currentContainer, deletedObject);
-						}
-					}
-
-				} else {
-					SceneUtils.deleteGameObject(currentContainer, gameObject);
-				}
-
 			}
 		}
 	}

--- a/editor/src/com/talosvfx/talos/editor/addons/scene/SceneUtils.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/SceneUtils.java
@@ -3,8 +3,6 @@ package com.talosvfx.talos.editor.addons.scene;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Camera;
-import com.badlogic.gdx.graphics.Texture;
-import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas.AtlasRegion;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.math.Vector3;
@@ -259,6 +257,26 @@ public class SceneUtils {
 
 		markContainerChanged(gameObjectContainer);
 
+	}
+
+	public static void deleteGameObjects (GameObjectContainer gameObjectContainer, ObjectSet<GameObject> gameObjects) {
+		for (GameObject gameObject : gameObjects) {
+			Array<GameObject> childrenToBeDeleted = new Array<>();
+			gameObject.clearChildren(childrenToBeDeleted);
+			gameObjects.addAll(childrenToBeDeleted);
+		}
+
+		for (GameObject gameObject : gameObjects) {
+			DeSelectGameObjectExternallyEvent deSelectGameObjectExternallyEvent = Notifications.obtainEvent(DeSelectGameObjectExternallyEvent.class);
+			deSelectGameObjectExternallyEvent.setGameObject(gameObject);
+			Notifications.fireEvent(deSelectGameObjectExternallyEvent);
+
+			GameObjectDeleted gameObjectDeleted = Notifications.obtainEvent(GameObjectDeleted.class);
+			gameObjectDeleted.set(gameObjectContainer, gameObject);
+			Notifications.fireEvent(gameObjectDeleted);
+		}
+
+		markContainerChanged(gameObjectContainer);
 	}
 
 	private static ObjectMap<GameObjectContainer, OrderedSet<GameObject>> copyPasteBuffer = new ObjectMap<>();

--- a/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/HierarchyWidget.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/HierarchyWidget.java
@@ -1,15 +1,11 @@
 package com.talosvfx.talos.editor.addons.scene.widgets;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.math.Vector2;
-import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
-import com.badlogic.gdx.scenes.scene2d.InputListener;
-import com.badlogic.gdx.scenes.scene2d.Touchable;
 import com.badlogic.gdx.scenes.scene2d.ui.*;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.badlogic.gdx.scenes.scene2d.utils.DragAndDrop;
@@ -49,8 +45,6 @@ import com.talosvfx.talos.runtime.scene.Scene;
 import lombok.Getter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static com.talosvfx.talos.editor.utils.InputUtils.ctrlPressed;
 
 public class HierarchyWidget extends Table implements Observer, EventContextProvider<GameObjectContainer> {
 
@@ -280,8 +274,11 @@ public class HierarchyWidget extends Table implements Observer, EventContextProv
             }
         }
 
-        for (GameObject object : selection) {
-            SceneUtils.deleteGameObject(currentContainer, object);
+        ObjectSet<GameObject> deleteList = new ObjectSet<>();
+        deleteList.addAll(selection);
+
+        if (currentContainer != null) {
+            SceneUtils.deleteGameObjects(currentContainer, deleteList);
         }
     }
 

--- a/runtimes/talos/src/main/java/com/talosvfx/talos/runtime/scene/GameObject.java
+++ b/runtimes/talos/src/main/java/com/talosvfx/talos/runtime/scene/GameObject.java
@@ -133,10 +133,10 @@ public class GameObject implements GameObjectContainer, RoutineEventListener, Js
 
     @Override
     public  Array<GameObject> deleteGameObject (GameObject gameObject) {
-        tmp.clear();
+        Array<GameObject> deletedGameObjects = new Array<>();
 
         String name = gameObject.getName();
-        if(childrenMap.containsKey(name)) {
+        if (childrenMap.containsKey(name)) {
             GameObject objectToRemove = childrenMap.get(name);
             childrenMap.remove(name);
             children.removeValue(objectToRemove, true);
@@ -145,7 +145,7 @@ public class GameObject implements GameObjectContainer, RoutineEventListener, Js
             objectToRemove.clearChildren(tmp);
         }
 
-        return tmp;
+        return deletedGameObjects;
     }
 
     @Override
@@ -159,6 +159,10 @@ public class GameObject implements GameObjectContainer, RoutineEventListener, Js
 
     @Override
     public void clearChildren (Array<GameObject> tmp) {
+        for (GameObject child : children) {
+            child.clearChildren(tmp);
+        }
+
         tmp.addAll(children);
 
         children.clear();


### PR DESCRIPTION
When removing game objects, gizmos of children objects were not cleaned up.