### PR TITLE
Bugfix: DirectoryView search crash

### DIFF
--- a/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/directoryview/DirectoryViewWidget.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/directoryview/DirectoryViewWidget.java
@@ -830,7 +830,7 @@ public class DirectoryViewWidget extends Table {
 	}
 
 	public FileHandle getCurrentFolder () {
-		return fileHandle;
+		return fileHandle != null ? fileHandle : SharedResources.currentProject.rootProjectDir();
 	}
 
 	private void navigateTo (FileHandle destination) {


### PR DESCRIPTION
Search would crash the talos, when no current folder was specified for directory view.