### PR TITLE
Bugfix: AppManager asset swap crashfix

### DIFF
--- a/editor/src/com/talosvfx/talos/editor/addons/scene/apps/spriteeditor/SpriteEditorApp.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/apps/spriteeditor/SpriteEditorApp.java
@@ -1,17 +1,15 @@
 package com.talosvfx.talos.editor.addons.scene.apps.spriteeditor;
 
-import com.badlogic.gdx.graphics.Texture;
-import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas.AtlasSprite;
 import com.badlogic.gdx.scenes.scene2d.Actor;
-import com.talosvfx.talos.runtime.assets.GameAsset;
 import com.talosvfx.talos.editor.layouts.DummyLayoutApp;
 import com.talosvfx.talos.editor.project2.AppManager;
 import com.talosvfx.talos.editor.project2.SharedResources;
 import com.talosvfx.talos.editor.project2.apps.SingletonApp;
+import com.talosvfx.talos.runtime.assets.GameAsset;
 
 @SingletonApp
-public class SpriteEditorApp extends AppManager.BaseApp<AtlasSprite> {
+public class SpriteEditorApp extends AppManager.BaseApp<AtlasSprite> implements GameAsset.GameAssetUpdateListener {
     private final SpriteEditor spriteEditor;
 
     public SpriteEditorApp () {
@@ -47,6 +45,10 @@ public class SpriteEditorApp extends AppManager.BaseApp<AtlasSprite> {
             return;
         }
 
+        if (!gameAsset.listeners.contains(this, true)) {
+            gameAsset.listeners.add(this);
+        }
+
         spriteEditor.updateForGameAsset(gameAsset);
     }
 
@@ -60,7 +62,12 @@ public class SpriteEditorApp extends AppManager.BaseApp<AtlasSprite> {
     }
 
     @Override
-    public void onRemove () {
+    public void onUpdate () {
+        getGridAppReference().updateTabName(getAppName());
+    }
 
+    @Override
+    public void onRemove () {
+        gameAsset.listeners.removeValue(this, true);
     }
 }

--- a/runtimes/talos/src/main/java/com/talosvfx/talos/runtime/assets/GameAsset.java
+++ b/runtimes/talos/src/main/java/com/talosvfx/talos/runtime/assets/GameAsset.java
@@ -89,13 +89,11 @@ public class GameAsset<T> {
 		if (this == o) return true;
 		if (!(o instanceof GameAsset)) return false;
 		GameAsset<?> other = (GameAsset<?>) o;
-		return other.type == this.type
-				&& Objects.equals(nameIdentifier, other.nameIdentifier)
-				&& Objects.equals(getRootRawAsset().metaData.uuid, other.getRootRawAsset().metaData.uuid);
+		return Objects.equals(getRootRawAsset().metaData.uuid, other.getRootRawAsset().metaData.uuid);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(nameIdentifier, type, getRootRawAsset().metaData.uuid);
+		return Objects.hash(getRootRawAsset().metaData.uuid);
 	}
 }


### PR DESCRIPTION
Because of bad hashing function, when swapping asset in app, which was renamed before, talos would crash.