### PR TITLE
Feature: Cut/Paste logic

### DIFF
--- a/editor/src/com/talosvfx/talos/editor/addons/scene/SceneEditorWorkspace.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/SceneEditorWorkspace.java
@@ -772,6 +772,7 @@ public class SceneEditorWorkspace extends ViewportWidget implements Json.Seriali
 		public Array<GameObject> objects = new Array<>();
 		public Array<Vector2> objectWorldPositions = new Array<>();
 		public Vector2 cameraPositionAtCopy = new Vector2(0, 0);
+		public boolean shouldCut = false;
 	}
 
 	public void copySelected () {
@@ -784,6 +785,16 @@ public class SceneEditorWorkspace extends ViewportWidget implements Json.Seriali
 		SceneUtils.copy(gameAsset, selection);
 	}
 
+	public void cutSelected () {
+
+		// TODO: 23.02.23 dummy refactor
+		if (currentContainer == null) {
+			return;
+		}
+
+		SceneUtils.cut(gameAsset, selection);
+	}
+
 	public void pasteFromClipboard () {
 
 		// TODO: 23.02.23 dummy refactor
@@ -791,6 +802,7 @@ public class SceneEditorWorkspace extends ViewportWidget implements Json.Seriali
 			return;
 		}
 
+		SceneUtils.shouldPasteToRoot(currentContainer);
 		SceneUtils.paste(gameAsset);
 	}
 

--- a/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/HierarchyWidget.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/HierarchyWidget.java
@@ -104,6 +104,7 @@ public class HierarchyWidget extends Table implements Observer, EventContextProv
                 addToSelectionEvent.set(currentContainer, gameObject);
                 Notifications.fireEvent(addToSelectionEvent);
 
+                SceneUtils.shouldPasteTo(currentContainer, getSelection().first());
             }
 
             @Override
@@ -115,14 +116,18 @@ public class HierarchyWidget extends Table implements Observer, EventContextProv
                 removeFromSelectionEvent.setGameObject(gameObject);
                 Notifications.fireEvent(removeFromSelectionEvent);
 
+                if (getSelection().isEmpty()) {
+                    SceneUtils.shouldPasteToRoot(currentContainer);
+                }
             }
 
             @Override
             public void clearSelection () {
                 super.clearSelection();
-
                 RequestSelectionClearEvent requestSelectionClearEvent = Notifications.obtainEvent(RequestSelectionClearEvent.class);
                 Notifications.fireEvent(requestSelectionClearEvent);
+
+                SceneUtils.shouldPasteToRoot(currentContainer);
             }
 
             @Override
@@ -257,13 +262,22 @@ public class HierarchyWidget extends Table implements Observer, EventContextProv
     }
 
     public void copySelected () {
+        OrderedSet<GameObject> selection = getSelection();
+        SceneUtils.copy(gameAsset, selection);
+    }
+
+    public void cutSelected () {
+        OrderedSet<GameObject> selection = getSelection();
+        SceneUtils.cut(gameAsset, selection);
+    }
+
+    public OrderedSet<GameObject> getSelection () {
         final Selection<FilteredTree.Node<GameObject>> selection = tree.getSelection();
         final OrderedSet<GameObject> arraySelection = new OrderedSet<>();
         for (FilteredTree.Node<GameObject> gameObjectNode : selection) {
             arraySelection.add(gameObjectNode.getObject());
         }
-
-        SceneUtils.copy(gameAsset, arraySelection);
+        return arraySelection;
     }
 
     public void deleteSelected () {
@@ -284,7 +298,6 @@ public class HierarchyWidget extends Table implements Observer, EventContextProv
     }
 
     public void pasteFromClipboard () {
-        tree.clearSelection(true);
         SceneUtils.paste(gameAsset);
     }
 
@@ -605,7 +618,7 @@ public class HierarchyWidget extends Table implements Observer, EventContextProv
 
     @EventHandler
     public void onGameObjectSelectionChanged(GameObjectSelectionChanged event) {
-        if(currentContainer != null) {
+        if (currentContainer != null) {
             ObjectSet<GameObject> gameObjects = event.get();
             Array<FilteredTree.Node<GameObject>> nodes = new Array<>();
             for(GameObject gameObject: gameObjects) {
@@ -618,7 +631,6 @@ public class HierarchyWidget extends Table implements Observer, EventContextProv
 
             tree.clearSelection(false);
             tree.addNodesToSelection(nodes, false);
-
 
             if (!nodes.isEmpty()) {
                 //Focus on first one

--- a/editor/src/com/talosvfx/talos/editor/project2/apps/SceneEditorApp.java
+++ b/editor/src/com/talosvfx/talos/editor/project2/apps/SceneEditorApp.java
@@ -106,6 +106,11 @@ public class SceneEditorApp extends AppManager.BaseApp<Scene> implements GameAss
 		workspaceWidget.copySelected();
 	}
 
+	@CommandEventHandler(commandType = Commands.CommandType.CUT)
+	public void onCutCommand (CommandContextEvent event) {
+		workspaceWidget.cutSelected();
+	}
+
 	@CommandEventHandler(commandType = Commands.CommandType.PASTE)
 	public void onPasteCommand (CommandContextEvent commandContextEvent) {
 		workspaceWidget.pasteFromClipboard();

--- a/editor/src/com/talosvfx/talos/editor/project2/apps/SceneHierarchyApp.java
+++ b/editor/src/com/talosvfx/talos/editor/project2/apps/SceneHierarchyApp.java
@@ -19,10 +19,12 @@ import com.talosvfx.talos.editor.project2.apps.preferences.ContainerOfPrefs;
 import com.talosvfx.talos.editor.project2.apps.preferences.HierarchyPreference;
 import com.talosvfx.talos.editor.project2.localprefs.TalosLocalPrefs;
 import com.talosvfx.talos.runtime.scene.Scene;
+import lombok.Getter;
 
 @SingletonApp
 public class SceneHierarchyApp extends AppManager.BaseApp<Scene> implements GameAsset.GameAssetUpdateListener, ContainerOfPrefs<HierarchyPreference>, Observer {
 
+	@Getter
 	private final HierarchyWidget hierarchyWidget;
 
 	public SceneHierarchyApp () {
@@ -149,6 +151,11 @@ public class SceneHierarchyApp extends AppManager.BaseApp<Scene> implements Game
 	@CommandEventHandler(commandType = Commands.CommandType.COPY)
 	public void onCopyCommand (CommandContextEvent event) {
 		hierarchyWidget.copySelected();
+	}
+
+	@CommandEventHandler(commandType = Commands.CommandType.CUT)
+	public void onCutCommand (CommandContextEvent event) {
+		hierarchyWidget.cutSelected();
 	}
 
 	@CommandEventHandler(commandType = Commands.CommandType.PASTE)

--- a/runtimes/talos/src/main/java/com/talosvfx/talos/runtime/scene/SavableContainer.java
+++ b/runtimes/talos/src/main/java/com/talosvfx/talos/runtime/scene/SavableContainer.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.UUID;
 import java.util.function.Supplier;
 
 public abstract class SavableContainer implements GameObjectContainer, Json.Serializable {
@@ -186,6 +187,16 @@ public abstract class SavableContainer implements GameObjectContainer, Json.Seri
 		load(TempHackUtil.hackIt(jsonString));
 	}
 
+
+	public GameObject getGameObject(UUID uuid) {
+		Array<GameObject> gameObjects = getGameObjects();
+		for (GameObject gameObject : gameObjects) {
+			if (gameObject.uuid.equals(uuid)) {
+				return gameObject;
+			}
+		}
+		return null;
+	}
 
 	public Array<GameObject> findGameObjects(String targetString) {
 		Array<GameObject> list = new Array<>();


### PR DESCRIPTION
Brought back game object cutting functionality. Also, changed logic for paste to take into account, if it should paste the game object as child or in root level. Logic is following, if target game object was specified from hierarchy widget, then paste as its child, otherwise paste on root level.