### PR TITLE
Bugfix: DirectoryViewWidget scroll issue

### DIFF
--- a/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/directoryview/DirectoryViewWidget.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/widgets/directoryview/DirectoryViewWidget.java
@@ -263,8 +263,8 @@ public class DirectoryViewWidget extends Table {
 		fileHandle = Gdx.files.absolute(path);
 
 		fillItems(directory);
-		invalidateHierarchy();
-		layout();
+		items.invalidateHierarchy();
+		items.layout();
 	}
 
 	private Array<FileHandle> convertToFileArray (Array<Item> selected) {


### PR DESCRIPTION
DirectoryViewWidget would not scroll, when new directory was selected. Called invalidate on wrong actor.