### PR TITLE
Bugfix: RepositoryOptimizer json crash

### DIFF
--- a/editor/src/com/talosvfx/talos/editor/addons/scene/assets/AssetRepository.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/assets/AssetRepository.java
@@ -11,16 +11,7 @@ import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.graphics.glutils.PixmapTextureData;
 import com.badlogic.gdx.scenes.scene2d.ui.TextField;
 import com.badlogic.gdx.tools.texturepacker.TexturePacker;
-import com.badlogic.gdx.utils.Array;
-import com.badlogic.gdx.utils.GdxRuntimeException;
-import com.badlogic.gdx.utils.Json;
-import com.badlogic.gdx.utils.JsonReader;
-import com.badlogic.gdx.utils.JsonValue;
-import com.badlogic.gdx.utils.JsonWriter;
-import com.badlogic.gdx.utils.Null;
-import com.badlogic.gdx.utils.ObjectMap;
-import com.badlogic.gdx.utils.ObjectSet;
-import com.badlogic.gdx.utils.Predicate;
+import com.badlogic.gdx.utils.*;
 import com.badlogic.gdx.utils.reflect.ClassReflection;
 import com.badlogic.gdx.utils.reflect.ReflectionException;
 import com.esotericsoftware.spine.SkeletonBinary;
@@ -592,7 +583,6 @@ public class AssetRepository extends BaseAssetRepository implements Observer {
 		} else {
 			logger.info("todo check all  other cases");
 		}
-
 
 		//Make deep copies
 		ObjectSet<GameAsset<?>> copiedAssets = new ObjectSet<>();

--- a/editor/src/com/talosvfx/talos/editor/addons/scene/assets/RepositoryOptimizer.java
+++ b/editor/src/com/talosvfx/talos/editor/addons/scene/assets/RepositoryOptimizer.java
@@ -15,6 +15,8 @@ import com.talosvfx.talos.runtime.assets.*;
 import com.talosvfx.talos.runtime.assets.meta.AtlasMetadata;
 import com.talosvfx.talos.runtime.assets.meta.SpriteMetadata;
 import lombok.Data;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -26,6 +28,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 
 public class RepositoryOptimizer {
+	private static final Logger logger = LoggerFactory.getLogger(RepositoryOptimizer.class);
 
 	@Data
 	public static class UnpackPayload {
@@ -250,9 +253,13 @@ public class RepositoryOptimizer {
 		boolean canSkipPacking = false;
 		if (settings.getExportPathHandle().child("assetExport.json").exists()) {
 			JsonReader reader = new JsonReader();
-			JsonValue exportInfo = reader.parse(settings.getExportPathHandle().child("assetExport.json"));
-			long prevAgeOfYoungestAsset = exportInfo.getLong("ageOfYoungestAsset", 0);
-			canSkipPacking = prevAgeOfYoungestAsset > 0 && ageOfYoungestAsset == prevAgeOfYoungestAsset;
+			try {
+				JsonValue exportInfo = reader.parse(settings.getExportPathHandle().child("assetExport.json"));
+				long prevAgeOfYoungestAsset = exportInfo.getLong("ageOfYoungestAsset", 0);
+				canSkipPacking = prevAgeOfYoungestAsset > 0 && ageOfYoungestAsset == prevAgeOfYoungestAsset;
+			} catch (SerializationException e) {
+				logger.warn("Bad old export, cannot skip packing ", e);
+			}
 		}
 
 		int i = 0;


### PR DESCRIPTION
Wrapped the json parsing for assetExport.json into try/catch for bad jsons. Will instead skip optimization and pack everything.