### PR TITLE
Bugfix: GameObject getChildrenByComponent

### DIFF
--- a/runtimes/talos/src/main/java/com/talosvfx/talos/runtime/scene/GameObject.java
+++ b/runtimes/talos/src/main/java/com/talosvfx/talos/runtime/scene/GameObject.java
@@ -352,9 +352,6 @@ public class GameObject implements GameObjectContainer, RoutineEventListener, Js
     }
 
     public Array<GameObject> getChildrenByComponent (Class<?> clazz, Array<GameObject> list) {
-        if (hasComponentType(clazz)) { //Check self in case of prefab
-            list.add(this);
-        }
         for(GameObject gameObject: children) {
             if(gameObject.hasComponentType(clazz)) {
                 list.add(gameObject);

--- a/runtimes/talos/src/main/java/com/talosvfx/talos/runtime/scene/components/SpineRendererComponent.java
+++ b/runtimes/talos/src/main/java/com/talosvfx/talos/runtime/scene/components/SpineRendererComponent.java
@@ -189,8 +189,6 @@ public class SpineRendererComponent extends RendererComponent implements Json.Se
             return;
         }
 
-        System.out.println("Populating GameObjects for " + skeleton.getData().getName());
-
         // clear old bones in map
         boneGOs.clear();
         directChildrenOfRoot.clear();


### PR DESCRIPTION
Fixed logic for getChildrenByComponent to not include the root itself, as it's not a child. Causes duplicates in the list...
Removed logging for debugging skels.